### PR TITLE
Vagrant environment and explaination of the examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vagrant/
+*.log
+kernel/

--- a/README.md
+++ b/README.md
@@ -47,14 +47,21 @@ wget -c https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.0.9.tar.gz -O - | t
 sudo mv linux-5.0.9 /kernel-src
 ```
 
-Please note: we could've done this in the Vagrant machine
+At this point, we need to compile the `libbpf` library:
 
-Now that you are in the machine, you can `cd` into the `/vagrant` folder, you'll find this
+```
+cd /kernel-src/tools/lib/bpf
+make
+```
+
+Now that you are in the machine and have everything, you can `cd` into the `/vagrant` folder, you'll find this
 repository in that folder since it's **one-time synced** between the VM and your Computer.
 
 ```
 cd /vagrant
 ```
+
+
 
 Now, you can follow the following code examples.
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ This is the companion code repo for the book [Linux Observability with BPF](http
 We believe that even if the examples included in the book were all tested and working when we wrote them, human error is possible and technology changes.
 For that reason, the purpose of this repo is to keep them as updated as possible and correct mistakes we made while writing the book.
 
-
 **Nota Bene**: All the examples in this repository are adapted from the book to assume that you use the Vagrant environment we provide.
 Examples can be slightly different in this repository because of that. The reason is that we didn't want to couple the book itself to Vagrant as a tool.
+If you don't want a Vagrant based environment, make sure you have: [bcc](https://github.com/iovisor/bcc/blob/master/INSTALL.md) and [clang](https://clang.llvm.org/)
+
 
 ## Vagrant Environment setup
 
@@ -29,25 +30,38 @@ cd linux-observability-with-bpf
 vagrant up
 ```
 
-This Vagrant command, will start an Ubuntu VM in Virtualbox, you can SSH into the machine using:
+This Vagrant command, will start a Fedora 30 VM in Virtualbox, you can SSH into the machine using:
 
 ```
 vagrant ssh
 ```
 
+Before going on, make sure you download the kernel source tree in this repository. It is needed as a dependency for some examples.
+We will be downloading the code for Kernel 5.0.9 - We are avoiding a git clone here because the Git history of the kernel is very big.
+
+In the machine:
+
+```bash
+cd /tmp
+wget -c https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.0.9.tar.gz -O - | tar -xz
+sudo mv linux-5.0.9 /kernel-src
+```
+
+Please note: we could've done this in the Vagrant machine
+
 Now that you are in the machine, you can `cd` into the `/vagrant` folder, you'll find this
-repository in that folder since it's shared between the VM and your Computer.
+repository in that folder since it's **one-time synced** between the VM and your Computer.
 
 ```
 cd /vagrant
 ```
 
-Now, you can 
-
+Now, you can follow the following code examples.
 
 ## Code examples
 
-Click on each example to follow the setup instructions:
+Click on each example to follow the setup instructions.
+
 
 ### Chapter 2
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,45 @@ We believe that even if the examples included in the book were all tested and wo
 For that reason, the purpose of this repo is to keep them as updated as possible and correct mistakes we made while writing the book.
 
 
+**Nota Bene**: All the examples in this repository are adapted from the book to assume that you use the Vagrant environment we provide.
+Examples can be slightly different in this repository because of that. The reason is that we didn't want to couple the book itself to Vagrant as a tool.
+
+## Vagrant Environment setup
+
+We provide reproducible environment in the form of a Vagrantfile that installs all the needed to make the exampples work.
+tools.
+
+### Install Vagrant
+
+To install Vagrant, follow the official guide [here](https://www.vagrantup.com/docs/installation/).
+
+Once you have Vagrant installed, you will need to clone this repository and issue a `vagrant up`.
+
+```bash
+git clone https://github.com/bpftools/linux-observability-with-bpf.git
+cd linux-observability-with-bpf
+vagrant up
+```
+
+This Vagrant command, will start an Ubuntu VM in Virtualbox, you can SSH into the machine using:
+
+```
+vagrant ssh
+```
+
+Now that you are in the machine, you can `cd` into the `/vagrant` folder, you'll find this
+repository in that folder since it's shared between the VM and your Computer.
+
+```
+cd /vagrant
+```
+
+Now, you can 
+
+
 ## Code examples
+
+Click on each example to follow the setup instructions:
 
 ### Chapter 2
 

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ Click on each example to follow the setup instructions.
 
 ### Chapter 7 - eXpress Data Path (XDP)
 
-- [XDP using iproute2 as a loader](/code/chapter-7/iproute2)
-- [XDP using BCC as a loader](/code/chapter-7/bcc)
+- [XDP and iproute2 as a loader](/code/chapter-7/iproute2)
+- [XDP and BCC](/code/chapter-7/bcc)
 - [Testing XDP programs](/code/chapter-7/prog-test-run)
 
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 $bootstrap=<<SCRIPT
-dnf install make glibc-devel.i686 elfutils-libelf-devel wget tar clang bcc strace -y
+dnf install make glibc-devel.i686 elfutils-libelf-devel wget tar clang bcc strace kernel-devel-5.0.9-301.fc30 -y
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 $bootstrap=<<SCRIPT
-dnf install elfutils-libelf-devel wget tar clang bcc -y
+dnf install make glibc-devel.i686 elfutils-libelf-devel wget tar clang bcc -y
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 $bootstrap=<<SCRIPT
-dnf install make glibc-devel.i686 elfutils-libelf-devel wget tar clang bcc -y
+dnf install make glibc-devel.i686 elfutils-libelf-devel wget tar clang bcc strace -y
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 $bootstrap=<<SCRIPT
-apt-get install bpfcc-tools linux-headers-$(uname -r)
+dnf install elfutils-libelf-devel wget tar clang bcc -y
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
@@ -12,14 +12,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   net_ip = "192.168.33.10"
 
   config.vm.define "bpfbook" do |net|
-  net.vm.box = "ubuntu/eoan64"
+  config.vm.box = "fedora/30-cloud-base"
+  config.vm.box_version = "30.20190425.0"
   net_index = 1
-  net.vm.hostname = "bpfbook"
-  net.vm.provider "virtualbox" do |vb|
+  config.vm.hostname = "bpfbook"
+  config.vm.provider "virtualbox" do |vb|
     vb.customize ["modifyvm", :id, "--memory", "1024"]
   end
-  net.vm.network :private_network, ip: "#{net_ip}"
-  net.vm.provision :shell, inline: $bootstrap, :args => "#{net_ip}"
+  config.vm.network :private_network, ip: "#{net_ip}"
+  config.vm.provision :shell, inline: $bootstrap, :args => "#{net_ip}"
 end
 end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,25 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+$bootstrap=<<SCRIPT
+apt-get install bpfcc-tools linux-headers-$(uname -r)
+SCRIPT
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  num_machines = 2
+  net_ip = "192.168.33.10"
+
+  config.vm.define "bpfbook" do |net|
+  net.vm.box = "ubuntu/eoan64"
+  net_index = 1
+  net.vm.hostname = "bpfbook"
+  net.vm.provider "virtualbox" do |vb|
+    vb.customize ["modifyvm", :id, "--memory", "1024"]
+  end
+  net.vm.network :private_network, ip: "#{net_ip}"
+  net.vm.provision :shell, inline: $bootstrap, :args => "#{net_ip}"
+end
+end
+

--- a/code/chapter-2/hello_world/compile-bpf.sh
+++ b/code/chapter-2/hello_world/compile-bpf.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 clang -O2 -target bpf \
-  -c bpf_program.c \ 
+  -c bpf_program.c \
   -o bpf_program.o

--- a/code/chapter-2/hello_world/compile-loader.sh
+++ b/code/chapter-2/hello_world/compile-loader.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
-TOOLS=../../../tools
-INCLUDE=../../../libbpf/include
-HEADERS=../../../libbpf/src
-clang -o loader -l elf \
+
+TOOLS=/kernel-src/samples/bpf
+INCLUDE=/kernel-src/tools/lib
+PERF_INCLUDE=/kernel-src/tools/perf
+KERNEL_TOOLS_INCLUDE=/kernel-src/tools/include/
+clang -o loader -lelf\
   -I${INCLUDE} \
-  -I${HEADERS} \
+  -I${PERF_INCLUDE} \
+  -I${KERNEL_TOOLS_INCLUDE} \
   -I${TOOLS} \
   ${TOOLS}/bpf_load.c \
   loader.c

--- a/code/chapter-2/hello_world/loader.c
+++ b/code/chapter-2/hello_world/loader.c
@@ -1,6 +1,5 @@
 #include "bpf_load.h"
 #include <stdio.h>
-#include <uapi/linux/bpf.h>
 
 int main(int argc, char **argv) {
   if (load_bpf_file("hello_world_kern.o") != 0) {

--- a/code/chapter-6/packet-filtering-raw-sockets/README.md
+++ b/code/chapter-6/packet-filtering-raw-sockets/README.md
@@ -1,0 +1,61 @@
+# Chapter 6: Packet filtering with Raw Sockets
+
+A full description of this example can be found in Chapter 6.
+
+If you follow this example from the book it will ask you to download kernel sources for `libbpf`
+and install the dependencies. However, since you are here you are following the examples
+in the Vagrant machine so all the dependencies are already handled if you followed the instructions in the main [README.md](/README.md).
+
+In the vagrant machine:
+
+Enter into this example folder:
+
+```bash
+cd /vagrant/code/chapter-6/packet-filtering-raw-sockets
+```
+
+Compile the loader
+
+```bash
+./build-loader.sh
+```
+
+It will create a binary file named `loader-bin`
+
+Compile the program
+
+```bash
+./build-bpf-program.sh
+```
+It will create a BPF ELF named `bpf-program.o`
+
+
+Execute the program using the loader:
+
+```
+./loader-bin bpf_program.o 
+```
+
+It will show something like this, ten results, one every second for ten seconds:
+
+```
+TCP 0 UDP 0 ICMP 0 packets
+TCP 0 UDP 0 ICMP 0 packets
+TCP 0 UDP 0 ICMP 0 packets
+TCP 0 UDP 0 ICMP 0 packets
+TCP 0 UDP 0 ICMP 4 packets
+TCP 0 UDP 0 ICMP 8 packets
+TCP 0 UDP 0 ICMP 12 packets
+TCP 0 UDP 0 ICMP 16 packets
+TCP 0 UDP 0 ICMP 16 packets
+TCP 0 UDP 0 ICMP 16 packets
+```
+
+Since the program is attached to the loopback interface `lo` (see `loader.c` line 30) we need to generate traffic on
+that interface to show the packets flow.
+
+You can simply do a ping to localhost in the VM while the program is running.
+
+```
+ping 127.0.0.1
+```

--- a/code/chapter-6/tc-flow-bpf-cls/README.md
+++ b/code/chapter-6/tc-flow-bpf-cls/README.md
@@ -1,0 +1,55 @@
+# Chapter 6: BPF-Based Traffic Control Classifier
+
+A full description of this example can be found in Chapter 6.
+
+Before reading this, make sure you follow the instructions to create the  Vagrant machine so all the dependencies are already handled, see the main [README.md](/README.md).
+
+In the vagrant machine:
+
+Enter into this example folder:
+
+```bash
+cd /vagrant/code/chapter-6/tc-flow-bpf-cls
+```
+
+Build the program
+
+```bash
+./build.sh
+```
+
+It will create an ELF file named `classifier.o`
+
+Now, since this example is using Traffic Control as a loader, we don't need to build a loader
+ourselves but we just use the `load.sh` script that uses `tc` to load the program on an interface
+passed as first argument.
+
+You can use it like this on the loopback (`lo`), or any other interface (`eth0`, etc..):
+
+```bash
+./load.sh lo
+```
+
+Since the program `classifier.c` writes with `bpf_trace_printk` it will dump the output to `/sys/kernel/debug/tracing/trace_pipe`.
+
+The classifier is written in a way that everytime an HTTP packet goes trough that interface it will print `Yes! It is HTTP!`.
+
+If you now do an http request to any HTTP server, e.g
+
+```bash
+curl https://bpf.sh
+```
+
+It will show:
+
+```
+[root@bpfbook ~]# cat /sys/kernel/debug/tracing/trace_pipe
+          <idle>-0     [000] ..s. 29775.178865: 0: Yes! It is HTTP!
+```
+
+
+At this point, you will want to unload the program, to do so:
+
+```bash
+./unload.sh lo
+```

--- a/code/chapter-6/tc-flow-bpf-cls/README.md
+++ b/code/chapter-6/tc-flow-bpf-cls/README.md
@@ -24,10 +24,10 @@ Now, since this example is using Traffic Control as a loader, we don't need to b
 ourselves but we just use the `load.sh` script that uses `tc` to load the program on an interface
 passed as first argument.
 
-You can use it like this on the loopback (`lo`), or any other interface (`eth0`, etc..):
+You can use it like this on the loopback (`eth0`), or any other interface (`lo`, `eth1` etc..):
 
 ```bash
-./load.sh lo
+sudo ./load.sh eth0
 ```
 
 Since the program `classifier.c` writes with `bpf_trace_printk` it will dump the output to `/sys/kernel/debug/tracing/trace_pipe`.
@@ -37,19 +37,19 @@ The classifier is written in a way that everytime an HTTP packet goes trough tha
 If you now do an http request to any HTTP server, e.g
 
 ```bash
-curl https://bpf.sh
+curl http://bpf.sh
 ```
 
 It will show:
 
 ```
-[root@bpfbook ~]# cat /sys/kernel/debug/tracing/trace_pipe
-          <idle>-0     [000] ..s. 29775.178865: 0: Yes! It is HTTP!
+[vagrant@bpfbook tc-flow-bpf-cls]$ sudo cat /sys/kernel/debug/tracing/trace_pipe
+          <idle>-0     [000] ..s. 30096.619165: 0: Yes! It is HTTP!
 ```
 
 
 At this point, you will want to unload the program, to do so:
 
 ```bash
-./unload.sh lo
+sudo ./unload.sh eth0
 ```

--- a/code/chapter-6/tc-flow-bpf-cls/build.sh
+++ b/code/chapter-6/tc-flow-bpf-cls/build.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-clang -O2 -target bpf -c classifier.c -o classifier.o
+clang  -g -c -O2 -target bpf -c classifier.c -o classifier.o

--- a/code/chapter-7/bcc/README.md
+++ b/code/chapter-7/bcc/README.md
@@ -1,0 +1,52 @@
+# Chapter 7: XDP and BCC
+
+A full description of this example can be found in Chapter 7.
+
+Before reading this, make sure you follow the instructions to create the  Vagrant machine so all the dependencies are already handled, see the main [README.md](/README.md).
+
+In the vagrant machine:
+
+Enter into this example folder:
+
+```bash
+cd /vagrant/code/chapter-7/bcc
+```
+
+In this folder, we have two files: `loader.py` and `program.c`. The last one is the actual program that we are
+going to compile and run, it just counts packets in a map and drops any TCP packet.
+
+We don't need to compile it because, since we are using BCC, compilation is handled by BCC itself at loading.
+
+Our loader, `loader.py` can be invoked with:
+
+Nota Bene: make sure to modify the loader `device` variable based on your needs. In the Vagrant environment, we have `eth0` and `eth1`. We used `eth1` because we are dropping TCP packets and we are connected to the instance trough TCP!
+
+```
+sudo ./loader.py
+```
+
+The program will now hang and will wait for output. When you `CTRL+C` it it will stop and unload the program automatically.
+
+Now that we have the program loaded, we can send some packets trough the `eth1` interface, a ping to the host instance
+can be a good way to try.
+
+If we issue a ping:
+```bash
+ping 192.168.33.1
+```
+
+We immediatelly see that the program starts printing results.
+```
+Printing packet counts per IP protocol-number, hit CTRL+C to stop
+0: 1 pkt/s
+1: 1 pkt/s
+0: 0 pkt/s
+1: 1 pkt/s
+0: 0 pkt/s
+1: 1 pkt/s
+0: 0 pkt/s
+```
+
+Where zero is just the default value for when there's no data and `1` is the value for ICMP
+packets. See the [Wikipedia page: List of IP protocol numbers](https://en.wikipedia.org/wiki/List_of_IP_protocol_numbers) for reference.
+

--- a/code/chapter-7/bcc/loader.py
+++ b/code/chapter-7/bcc/loader.py
@@ -1,10 +1,10 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from bcc import BPF
 import time
 import sys
 
-device = "enp0s8"
+device = "eth1"
 b = BPF(src_file="program.c")
 fn = b.load_func("myprogram", BPF.XDP)
 b.attach_xdp(device, fn, 0)

--- a/code/chapter-7/iproute2/README.md
+++ b/code/chapter-7/iproute2/README.md
@@ -1,0 +1,33 @@
+# Chapter 7: XDP and iproute2 as a loader
+
+A full description of this example can be found in Chapter 7. It contains shows how to use this program against a webserver and has a full explanation of the arguments used. Please refer to the book.
+
+Before reading this, make sure you follow the instructions to create the  Vagrant machine so all the dependencies are already handled, see the main [README.md](/README.md).
+
+In the vagrant machine:
+
+Enter into this example folder:
+
+```bash
+cd /vagrant/code/chapter-7/iproute2
+```
+
+You can now use the `compile.sh` script to create the `program.o` ELF file.
+
+
+Now that you have it, you can load the program to an interface. We will use `eth1` again because the program
+blocks TCP packets and we are connected to the Vagrant machine trough SSH :)
+
+```bash
+sudo ip link set dev eth1 xdp obj program.o sec mysection
+```
+
+
+Please note that you can see that the program was loaded by doing an `ip a` and looking for `xdpgeneric` in the `eth` network interface.
+
+
+To unload the program you have to do:
+
+```bash
+sudo ip link set dev eth1 xdp off
+```

--- a/code/chapter-7/iproute2/compile.sh
+++ b/code/chapter-7/iproute2/compile.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-clang -O2 -target bpf -c program.c -o program.o
+clang -g -c -O2 -target bpf -c program.c -o program.o

--- a/code/chapter-7/prog-test-run/README.md
+++ b/code/chapter-7/prog-test-run/README.md
@@ -1,1 +1,43 @@
-Show how to use BPF_PROG_TEST_RUN.
+# Chapter 7: Testing XDP programs
+
+A full description of this example can be found in Chapter 7. It explains the various steps better and walks you trough the code here.
+
+Before reading this, make sure you follow the instructions to create the  Vagrant machine so all the dependencies are already handled, see the main [README.md](/README.md).
+
+In the vagrant machine:
+
+Enter into this example folder:
+
+```bash
+cd /vagrant/code/chapter-7/prog-test-run
+```
+
+First let's gather some dependencies.
+
+We already have the BCC python library, coming from the BCC package provisioned in the Vagrantfile, but we need
+to install scapy.
+
+```
+sudo pip3 install scapy
+```
+
+Now we can take a look at our `program.c`, this program has different actions based on the destination
+mac address and packet type. What we want to achieve, is to write a test suite to verify that the program behaves correctly.
+
+Our test suite is defined in the `test_xdp.py` program, let's run it:
+
+```bash
+sudo python3 test_xdp.py
+```
+
+Expected output:
+
+```
+...
+----------------------------------------------------------------------
+Ran 3 tests in 5.618s
+
+OK
+```
+
+Try to play with the XDP program in `program.c` and run the test suite again, what happens?

--- a/code/chapter-8/seccomp/README.md
+++ b/code/chapter-8/seccomp/README.md
@@ -1,0 +1,67 @@
+# Chapter 8: Linux Kernel security, Capabilities and Seccomp
+
+A full description of this example can be found in Chapter 8. It explains the various steps better and walks you trough the code here.
+
+Before reading this, make sure you follow the instructions to create the  Vagrant machine so all the dependencies are already handled, see the main [README.md](/README.md).
+
+In the vagrant machine:
+
+Enter into this example folder:
+
+```bash
+cd /vagrant/code/chapter-8/seccomp
+```
+
+
+Compiling this program is very straightforward, you just do a:
+
+
+```bash
+clang main.c -o filter-write
+```
+
+The program is made to filter any write syscall that happens, if you try it using a command that is supposed
+to write it will not print anything.
+
+
+Let's first do a command that prints stuff, like `ls -la`:
+
+```bash
+[vagrant@bpfbook seccomp]$ ls -la
+total 40
+drwxr-xr-x. 2 vagrant vagrant  4096 Dec 10 01:07 .
+drwxr-xr-x. 3 vagrant vagrant  4096 Oct 29 16:59 ..
+-rwxrwxr-x. 1 vagrant vagrant 22016 Dec 10 01:07 filter-write
+-rw-r--r--. 1 vagrant vagrant    19 Oct 29 16:59 .gitignore
+-rw-r--r--. 1 vagrant vagrant  1210 Oct 29 16:59 main.c
+```
+
+Now let's do the same with `filter-write`:
+
+```
+[vagrant@bpfbook seccomp]$ ./filter-write "ls -la"
+```
+
+No output! Let's see why!
+
+We can use `strace` to dig into this:
+
+```bash
+strace -f ./filter-write "ls -la"
+[pid  2657] lstat(".gitignore", {st_mode=S_IFREG|0644, st_size=19, ...}) = 0
+[pid  2657] lgetxattr(".gitignore", "security.selinux", "unconfined_u:object_r:default_t:"..., 255) = 35
+[pid  2657] getxattr(".gitignore", "system.posix_acl_access", NULL, 0) = -1 ENODATA (No data available)
+[pid  2657] getdents64(3, /* 0 entries */, 32768) = 0
+[pid  2657] close(3)                    = 0
+[pid  2657] openat(AT_FDCWD, "/usr/share/locale/en_US.UTF-8/LC_MESSAGES/coreutils.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
+[pid  2657] openat(AT_FDCWD, "/usr/share/locale/en_US.utf8/LC_MESSAGES/coreutils.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
+[pid  2657] openat(AT_FDCWD, "/usr/share/locale/en_US/LC_MESSAGES/coreutils.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
+[pid  2657] openat(AT_FDCWD, "/usr/share/locale/en.UTF-8/LC_MESSAGES/coreutils.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
+[pid  2657] openat(AT_FDCWD, "/usr/share/locale/en.utf8/LC_MESSAGES/coreutils.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
+[pid  2657] openat(AT_FDCWD, "/usr/share/locale/en/LC_MESSAGES/coreutils.mo", O_RDONLY) = -1 ENOENT (No such file or directory)
+```
+
+All the write syscalls got `ENOENT` as defined in `main.c`, that's why no output was given!
+
+
+


### PR DESCRIPTION
Opening this PR to address the concern that many readers had about being able to compile and run some of  the examples.

This contains:

- [x] A Vagrantfile containing all the needed dependencies to compile and execute the examples
- [x] Updated the Readme with instructions for the Vagrantfile and for getting a copy of the kernel source
- [ ] Make sure all the examples work and have a matching description to complement the book
  - [ ] [Hello World](/bpftools/linux-observability-with-bpf/tree/master/code/chapter-2/hello_world)
  - [ ] [Kprobes](/bpftools/linux-observability-with-bpf/tree/master/code/chapter-4/kprobes)
  - [ ] [Kretprobes](/bpftools/linux-observability-with-bpf/tree/master/code/chapter-4/kretprobes)
  - [ ] [Uprobes](/bpftools/linux-observability-with-bpf/tree/master/code/chapter-4/uprobes)
  - [ ] [Uretprobes ](/bpftools/linux-observability-with-bpf/tree/master/code/chapter-4/uretprobes)
  - [ ]  [Tracepoints](/bpftools/linux-observability-with-bpf/tree/master/code/chapter-4/tracepoints)
  - [ ] [User Statically Defined Tracepoints](/bpftools/linux-observability-with-bpf/tree/master/code/chapter-4/usdt)
  - [ ] [Flame Graphs](/bpftools/linux-observability-with-bpf/tree/master/code/chapter-4/flamegraphs)
  - [ ] [Histograms](/bpftools/linux-observability-with-bpf/tree/master/code/chapter-4/histograms)
  - [ ] [Perf Events](/bpftools/linux-observability-with-bpf/tree/master/code/chapter-4/histograms)
  - [x]  [Packet filtering for raw sockets](/bpftools/linux-observability-with-bpf/tree/master/code/chapter-6/packet-filtering-raw-sockets)
  - [x] [Traffic control classifier program using cls_bpf](/bpftools/linux-observability-with-bpf/tree/master/code/chapter-6/tc-flow-bpf-cls)
  - [x] [XDP using iproute2 as a loader](/bpftools/linux-observability-with-bpf/tree/master/code/chapter-7/iproute2)
  - [x] [XDP using BCC as a loader](/bpftools/linux-observability-with-bpf/tree/master/code/chapter-7/bcc)
  - [x] [Testing XDP programs](/bpftools/linux-observability-with-bpf/tree/master/code/chapter-7/prog-test-run)
  - [x] [Seccomp BPF filter example](/bpftools/linux-observability-with-bpf/tree/master/code/chapter-8/seccomp)

