### PR TITLE
added uapi/linux/ptrace.h for struct pt_regs definition

### DIFF
--- a/code/chapter-4/kprobes/example.py
+++ b/code/chapter-4/kprobes/example.py
@@ -1,6 +1,8 @@
 from bcc import BPF
 
 bpf_source = """
+#include <uapi/linux/ptrace.h>
+
 int do_sys_execve(struct pt_regs *ctx, void filename, void argv, void envp) {
   char comm[16];
   bpf_get_current_comm(&comm, sizeof(comm));

--- a/code/chapter-4/kretprobes/example.py
+++ b/code/chapter-4/kretprobes/example.py
@@ -1,6 +1,8 @@
 from bcc import BPF
 
 bpf_source = """
+#include <uapi/linux/ptrace.h>
+
 int ret_sys_execve(struct pt_regs *ctx) {
   int return_value;
   char comm[16];


### PR DESCRIPTION
relates to https://github.com/bpftools/linux-observability-with-bpf/issues/15

fixed the issue by adding missing `<uapi/linux/ptrace.h>` include.

Also, for people testing on Ubuntu 18.04, BCC should be installed from iovisor.org repository and not from Ubuntu one. The one from Ubuntu does not have the fix for `asm goto` (described here) https://github.com/iovisor/bcc/issues/2534