### PR TITLE
Chapter 2: load bpf program with root privilege

### DIFF
--- a/code/chapter-2/hello_world/README.md
+++ b/code/chapter-2/hello_world/README.md
@@ -28,7 +28,7 @@ It will create a BPF ELF named `bpf-program.o` and a Loader named `monitor-exec`
 Now you can execute the bpf program with root privileges and leave it running.
 
 ```
-# ./monitor-exec
+# sudo ./monitor-exec
 ```
 
 The program is made in a way that everytime an `execve` syscall is executed it prints `Hello, BPF World!`.


### PR DESCRIPTION
The original command `./monitor-exec` does not have root privilege. Upon running it, we will see an error:
```
bpf_load_program() err=1
The kernel didn't load the BPF program
```

Adding `sudo` fixes that.