### PR TITLE
Chapter 2: remove clang make target

### DIFF
--- a/code/chapter-2/hello_world/Makefile
+++ b/code/chapter-2/hello_world/Makefile
@@ -16,7 +16,7 @@ LOADINCLUDE += -I/kernel-src/tools/include
 LIBRARY_PATH = -L/usr/local/lib64
 BPFSO = -lbpf
 
-.PHONY: clean $(CLANG) bpfload build
+.PHONY: clean bpfload build
 
 clean:
 	rm -f *.o *.so $(EXECABLE)


### PR DESCRIPTION
`make clang` does nothing but throwing an error. We can just remove it to avoid confusion.

This is harmless though, so this is just a P2.