### PR TITLE
Chapter 2: set -DHAVE_ATTR_TEST=0 when necessary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vagrant/
 *.log
 kernel/
+code/chapter-2/hello_world/bpf_program.o
+code/chapter-2/hello_world/monitor-exec

--- a/code/chapter-2/hello_world/Makefile
+++ b/code/chapter-2/hello_world/Makefile
@@ -16,6 +16,23 @@ LOADINCLUDE += -I/kernel-src/tools/include
 LIBRARY_PATH = -L/usr/local/lib64
 BPFSO = -lbpf
 
+# Setting -DHAVE_ATTR_TEST=0 for the kernel containing below patch:
+# 06f84d1989b7 perf tools: Make usage of test_attr__* optional for perf-sys.h
+#
+# The patch was included in Linus's tree starting v5.5-rc1, but was also included
+# in stable kernel branch linux-5.4.y. So it's hard to determine whether a kernel
+# is affected based on the kernel version alone:
+# - for a v5.4 kernel from Linus's tree, no;
+# - for a v5.4 kernel from the stable tree (used by many distros), yes.
+#
+# So let's look at the actual kernel source code to decide.
+#
+# See more context at:
+# https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=06f84d1989b7e58d56fa2e448664585749d41221
+# https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=fce9501aec6bdda45ef3a5e365a5e0de7de7fe2d
+CFLAGS += $(shell grep -q "define HAVE_ATTR_TEST 1" /kernel-src/tools/perf/perf-sys.h \
+                  && echo "-DHAVE_ATTR_TEST=0")
+
 .PHONY: clean $(CLANG) bpfload build
 
 clean:
@@ -25,7 +42,7 @@ build: ${BPFCODE.c} ${BPFLOADER}
 	$(CLANG) -O2 -target bpf -c $(BPFCODE:=.c) $(CCINCLUDE) -o ${BPFCODE:=.o}
 
 bpfload: build
-	clang -o $(EXECABLE) -lelf $(LOADINCLUDE) $(LIBRARY_PATH) $(BPFSO) \
+	clang $(CFLAGS) -o $(EXECABLE) -lelf $(LOADINCLUDE) $(LIBRARY_PATH) $(BPFSO) \
         $(BPFLOADER) loader.c
 
 $(EXECABLE): bpfload


### PR DESCRIPTION
Setting -DHAVE_ATTR_TEST=0 for the kernel containing below patch:
06f84d1989b7 perf tools: Make usage of test_attr__* optional for perf-sys.h

The patch was included in Linus's tree starting v5.5-rc1, but was also included in stable kernel branch linux-5.4.y. So it's hard to determine whether a kernel is affected based on the kernel version alone:
- for a v5.4 kernel from Linus's tree, no;
- for a v5.4 kernel from the stable tree (used by many distros), yes.

So let's look at the actual kernel source code to decide.

See more context at:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=06f84d1989b7e58d56fa2e448664585749d41221
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=fce9501aec6bdda45ef3a5e365a5e0de7de7fe2d

I have tested this on the Vagrant environment and a Ubuntu 20.04 VM (focal, with a 5.4 stable kernel).

Thanks for the reference from @wybczu at https://github.com/bpftools/linux-observability-with-bpf/issues/25#issuecomment-596258375. This should help closing https://github.com/bpftools/linux-observability-with-bpf/issues/25.