### PR TITLE
Add libraries for ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ sudo apt update
 sudo apt install build-essential git make libelf-dev clang strace tar bpfcc-tools linux-headers-$(uname -r) gcc-multilib
 
 # Ubuntu 20.04
-sudo apt install build-essential git make libelf-dev clang strace tar bpfcc-tools linux-headers-$(uname -r) gcc-multilib libreadline-dev binutils-dev  
+sudo apt install build-essential git make libelf-dev clang strace tar bpfcc-tools linux-headers-$(uname -r) gcc-multilib libreadline-dev binutils-dev bison flex  
 ```
 
 **Note on Kernel version**: make sure to have a recent kernel to run the examples, a version `>=5.0.0` will do the job. Most Ubuntu `18.04` providers are shipping with the kernel `4.15` that doesn't work for most of the examples. Upgrading options are left to the reader, we've been successful on aws by installing the `linux-image-5.0.0-1019-aws` package.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ sudo dnf install make glibc-devel.i686 elfutils-libelf-devel wget tar clang bcc 
 
 Then we need grab a copy of the source code of the current kernel.
 
-In our case the kernel runing can be verified with `uname`.
+In our case the kernel running can be verified with `uname`.
 
 ```bash
 $ uname -r
@@ -61,13 +61,17 @@ sudo make && sudo make install prefix=/
 </details>
 
 <details>
-<summary>Ubuntu 18.04</summary>
+<summary>Ubuntu 18.04/20.04</summary>
 
 First, we need to install some build dependencies and all the tools needed for the examples:
 
 ```bash
 sudo apt update
+# Ubuntu 18.04
 sudo apt install build-essential git make libelf-dev clang strace tar bpfcc-tools linux-headers-$(uname -r) gcc-multilib
+
+# Ubuntu 20.04
+sudo apt install build-essential git make libelf-dev clang strace tar bpfcc-tools linux-headers-$(uname -r) gcc-multilib libreadline-dev binutils-dev  
 ```
 
 **Note on Kernel version**: make sure to have a recent kernel to run the examples, a version `>=5.0.0` will do the job. Most Ubuntu `18.04` providers are shipping with the kernel `4.15` that doesn't work for most of the examples. Upgrading options are left to the reader, we've been successful on aws by installing the `linux-image-5.0.0-1019-aws` package.
@@ -94,7 +98,7 @@ cd /kernel-src/tools/lib/bpf
 sudo make && sudo make install prefix=/usr/local
 ```
 
-Ubuntu doesn't have the library path that the makefile expects so we need to move our libraries
+Ubuntu 18.04 doesn't have the library path that the makefile expects so we need to move our libraries
 to its library path now.
 
 ```


### PR DESCRIPTION
I was having the below issue in ubuntu 20.04, so need to install two more additional package libreadline-dev, binutils-dev, bson, flex

<details>
<summary>Before</summary>

```shell scripts
vagrant@ubuntu-focal:/kernel-src/tools/bpf$ make && sudo make install prefix=/

Auto-detecting system features:
...                        libbfd: [ OFF ]
...        disassembler-four-args: [ OFF ]

  CC       bpf_jit_disasm.o
/kernel-src/tools/bpf/bpf_jit_disasm.c:23:10: fatal error: bfd.h: No such file or directory
   23 | #include <bfd.h>
      |          ^~~~~~~
compilation terminated.
make: *** [Makefile:57: bpf_jit_disasm.o] Error 1


vagrant@ubuntu-focal:/kernel-src/tools/bpf$ make && sudo make install prefix=/

Auto-detecting system features:
...                        libbfd: [ on  ]
...        disassembler-four-args: [ on  ]

  CC       bpf_jit_disasm.o
  LINK     bpf_jit_disasm
  CC       bpf_dbg.o
```

</details>

<details>
<summary>After</summary>

```shell scripts
vagrant@ubuntu-focal:/kernel-src/tools/bpf$ make && sudo make install prefix=/
  FLEX     bpf_exp.lex.c
  CC       bpf_exp.lex.o
  LINK     bpf_asm
  DESCEND  bpftool

Auto-detecting system features:
...                        libbfd: [ on  ]
...        disassembler-four-args: [ on  ]

  CC       map_perf_ring.o
  CC       xlated_dumper.o
  CC       tracelog.o
  CC       perf.o
  CC       prog.o
  CC       btf_dumper.o
  CC       net.o
  CC       netlink_dumper.o
  CC       common.o
  CC       cgroup.o
  CC       main.o
  CC       json_writer.o
  CC       cfg.o
  CC       map.o
  CC       jit_disasm.o
  CC       disasm.o

Auto-detecting system features:
...                        libelf: [ on  ]
...                           bpf: [ on  ]

  CC       libbpf.o
  CC       bpf.o
  CC       nlattr.o
  CC       btf.o
  CC       libbpf_errno.o
  CC       str_error.o
  CC       netlink.o
  CC       bpf_prog_linfo.o
  LD       libbpf-in.o
  LINK     libbpf.a
  LINK     bpftool
  DESCEND  bpftool
  INSTALL  bpftool
  INSTALL  bpf_jit_disasm
  INSTALL  bpf_dbg
  INSTALL  bpf_asm
```

</details>
