### PR TITLE
Fix tiny typo in xdp test README

### DIFF
--- a/code/chapter-7/prog-test-run/README.md
+++ b/code/chapter-7/prog-test-run/README.md
@@ -1,6 +1,6 @@
 # Chapter 7: Testing XDP programs
 
-- A full description of this example can be found in Chapter 7. It explains the various steps better and walks you trough the code here.
+- A full description of this example can be found in Chapter 7. It explains the various steps better and walks you through the code here.
 - Please remember that the examples here are tested in the Vagrant machine. Please read more in [README.md](/README.md).
 - Make sure to change the example accordingly if you wish to build somewhere else, open an issue if you have problems doing so!
 - All the dependencies are already handled if you followed the instructions in the main [README.md](/README.md).


### PR DESCRIPTION
Just spotted it while reading the readme