### PR TITLE
Fix path

### DIFF
--- a/code/chapter-4/uprobes/example.py
+++ b/code/chapter-4/uprobes/example.py
@@ -9,5 +9,5 @@ int trace_go_main(struct pt_regs *ctx) {
 """
 
 bpf = BPF(text = bpf_source)
-bpf.attach_uprobe(name = "hello-bpf", sym = "main.main", fn_name = "trace_go_main")
+bpf.attach_uprobe(name = "./hello-bpf", sym = "main.main", fn_name = "trace_go_main")
 bpf.trace_print()

--- a/code/chapter-4/uretprobes/example.py
+++ b/code/chapter-4/uretprobes/example.py
@@ -25,6 +25,6 @@ int print_duration(struct pt_regs *ctx) {
 """
 
 bpf = BPF(text = bpf_source)
-bpf.attach_uprobe(name = "hello-bpf", sym = "main.main", fn_name = "trace_start_time")
-bpf.attach_uretprobe(name = "hello-bpf", sym = "main.main", fn_name = "print_duration")
+bpf.attach_uprobe(name = "./hello-bpf", sym = "main.main", fn_name = "trace_start_time")
+bpf.attach_uretprobe(name = "./hello-bpf", sym = "main.main", fn_name = "print_duration")
 bpf.trace_print()


### PR DESCRIPTION
When running examples of uprobe and uretprobe, I got:
```
Exception: could not determine address of symbol b'main.main'
```
We should give the correct path