### PR TITLE
Fix some code in Chapter 4

### DIFF
--- a/code/chapter-4/usdt/example.py
+++ b/code/chapter-4/usdt/example.py
@@ -4,11 +4,11 @@ bpf_source = """
 #include <uapi/linux/ptrace.h>
 int trace_binary_exec(struct pt_regs *ctx) {
   u64 pid = bpf_get_current_pid_tgid();
-  bpf_trace_printk("New hello_usdt process running with PID: %d", pid);
+  bpf_trace_printk("New hello_usdt process running with PID: %d\\n", pid);
 }
 """
 
 usdt = USDT(path = "./hello_usdt")
 usdt.enable_probe(probe = "probe-main", fn_name = "trace_binary_exec")
-bpf = BPF(text = bpf_source, usdt = usdt)
+bpf = BPF(text = bpf_source, usdt_contexts = [usdt])
 bpf.trace_print()

--- a/code/chapter-4/usdt/hello_usdt.c
+++ b/code/chapter-4/usdt/hello_usdt.c
@@ -1,7 +1,7 @@
 #include <sys/sdt.h>
 
 int main(int argc, char const *argv[]) {
-    DTRACE_PROBE("hello-usdt", "probe-main");
+    DTRACE_PROBE(hello-usdt, probe-main);
     return 0;
 }
 


### PR DESCRIPTION
1. When running examples of USDT, I got
```
  File "example.py", line 11, in <module>
    usdt.enable_probe(probe = "probe-main" , fn_name = "trace_binary_exec")
  File "/usr/lib/python3/dist-packages/bcc/usdt.py", line 151, in enable_probe
    raise USDTException(
bcc.usdt.USDTException: failed to enable probe 'probe-main'; a possible cause can be that the probe requires a pid to enable
```

It's because the addtional quotes make the probe name become `""probe-main""`, so we should remove them, see https://stackoverflow.com/questions/62641551/getting-bpf-programs-working-with-usdt-probes-dtrace-in-linux

2. There is no argument "usdt" in BPF constructor
```
  File "example.py", line 12, in <module>
    bpf = BPF(text = bpf_source, usdt = usdt)
TypeError: __init__() got an unexpected keyword argument 'usdt'
```
We should use `usdt_contexts = [usdt]` instead.