### PR TITLE
Chapter 4: replace %d specifier with %llu in uretprobe example

### DIFF
--- a/code/chapter-4/uretprobes/example.py
+++ b/code/chapter-4/uretprobes/example.py
@@ -19,7 +19,7 @@ int print_duration(struct pt_regs *ctx) {
     return 0;
   }
   u64 duration_ns = bpf_ktime_get_ns() - *start_time_ns;
-  bpf_trace_printk("Function call duration: %d\\n", duration_ns);
+  bpf_trace_printk("Function call duration: %llu\\n", duration_ns);
   return 0;
 }
 """


### PR DESCRIPTION
I started to play with the example given for **uretprobe** in chapter 4. When tracing programs with execution time in the order of magnitude of seconds I started to observe a wrong duration result, as you can see in the following example (I changed the program a bit to get the start and end time):

```bash
$ python3 uretprobes.py &
$ time ./hello-bpf 
b'           <...>-25604   [001] .... 11061.354615: 0: start time: -449378215'
Hello, BPF
b'       hello-bpf-25604   [001] .... 11071.355454: 0: End Time: 961530479'
b'Function call duration: 1410908694'

real	0m10.010s
user	0m0.000s
sys	0m0.008s
```
I suspected the following line was the culprit, while a duration greater than 2 seconds doesn't fit in a 32-bit integer as expected by %d.

```c
bpf_trace_printk("Function call duration: %d\\n", duration_ns);
```
