### PR TITLE
add sudo

### DIFF
--- a/code/chapter-2/hello_world/README.md
+++ b/code/chapter-2/hello_world/README.md
@@ -28,7 +28,7 @@ It will create a BPF ELF named `bpf-program.o` and a Loader named `monitor-exec`
 Now you can execute the bpf program with root privileges and leave it running.
 
 ```
-# ./monitor-exec
+# sudo ./monitor-exec
 ```
 
 The program is made in a way that everytime an `execve` syscall is executed it prints `Hello, BPF World!`.


### PR DESCRIPTION
I think one of the reasons that cause the below error (related to #25 ) is that the command was not executed with the root privileges, though it is mentioned in the instruction but people tends to copy and paste the code:
```bash
[vagrant@bpfbook hello_world]$ ./monitor-exec
bpf_load_program() err=1
The kernel didn't load the BPF program
```